### PR TITLE
Revert removal of Guava from plugin classpath #35

### DIFF
--- a/com.incquerylabs.v4md/build.gradle
+++ b/com.incquerylabs.v4md/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     pub group: 'org.eclipse.viatra', name: 'viatra-query-runtime', version: viatraVersion, exclusions
     pub group: 'org.eclipse.viatra', name: 'viatra-transformation-runtime', version: viatraVersion, exclusions
     pub group: 'org.eclipse.viatra', name: 'viatra-transformation-debugger-runtime', version: viatraIncubationVersion, exclusions
+    pub group: 'com.google.guava', name: 'guava', version: '21.0'
     
         
     
@@ -114,7 +115,6 @@ dependencies {
     }
     
     testCompile group: 'org.eclipse.xtend', name: 'org.eclipse.xtend.lib', version: xtextVersion, exclusions
-    testCompile group: 'com.google.guava', name: 'guava', version: '21.0'
     testCompile 'org.apache.maven.surefire:maven-surefire-common:2.19.1'
     testCompile 'org.apache.maven.surefire:surefire-api:2.19.1'
     testCompile 'org.apache.maven.surefire:surefire-junit4:2.19.1'


### PR DESCRIPTION
VIATRA 2.2 runtime uses Guava classes internally, making it necessary to
have Guava on the public classpath