### PR TITLE
Guava-free V4MD runtime

### DIFF
--- a/com.incquerylabs.v4md/build.gradle
+++ b/com.incquerylabs.v4md/build.gradle
@@ -102,7 +102,6 @@ dependencies {
     pub group: 'org.eclipse.viatra', name: 'viatra-query-runtime', version: viatraVersion, exclusions
     pub group: 'org.eclipse.viatra', name: 'viatra-transformation-runtime', version: viatraVersion, exclusions
     pub group: 'org.eclipse.viatra', name: 'viatra-transformation-debugger-runtime', version: viatraIncubationVersion, exclusions
-    pub group: 'com.google.guava', name: 'guava', version: '21.0'
     
         
     
@@ -118,6 +117,7 @@ dependencies {
     testCompile 'org.apache.maven.surefire:maven-surefire-common:2.19.1'
     testCompile 'org.apache.maven.surefire:surefire-api:2.19.1'
     testCompile 'org.apache.maven.surefire:surefire-junit4:2.19.1'
+    testCompile group: 'com.google.guava', name: 'guava', version: '21.0'
     testCompile group: 'org.eclipse.viatra', name: 'viatra-query-testing', version: viatraVersion, testExclusions
 }
 

--- a/com.incquerylabs.v4md/gradle.properties
+++ b/com.incquerylabs.v4md/gradle.properties
@@ -1,8 +1,8 @@
-version=2.2.2-SNAPSHOT
-buildNumber=222010
+version=2.3.0-SNAPSHOT
+buildNumber=230010
 group=com.incquerylabs.v4md
-viatraVersion=2.2.1
-viatraIncubationVersion=0.22.1
+viatraVersion=2.3.0-SNAPSHOT
+viatraIncubationVersion=0.23.0-SNAPSHOT
 deployUrl = "build/maven-repository"
 xtextVersion=2.18.0
 deployReleaseUrl=https://build.incquerylabs.com/nexus/repository/v4md-releases/


### PR DESCRIPTION
This PR increases VIATRA dependencies to 2.3.0-SNAPSHOT and remove explicit Guava dependencies from the normal runtime.