### PR TITLE
Ensures IncrementalTransformationSynchronizer cleanup on project close

### DIFF
--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/V4MDPlugin.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/V4MDPlugin.java
@@ -2,6 +2,7 @@ package com.incquerylabs.v4md;
 
 import com.incquerylabs.v4md.expressions.BinaryVQLExpression;
 import com.incquerylabs.v4md.internal.IProjectChangedListener;
+import com.incquerylabs.v4md.transformations.IncrementalTransformationSynchronizer;
 import com.nomagic.ci.persistence.IProject;
 import com.nomagic.magicdraw.core.Application;
 import com.nomagic.magicdraw.core.Project;
@@ -18,6 +19,7 @@ public class V4MDPlugin extends com.nomagic.magicdraw.plugins.Plugin {
 		@Override
 		public void projectPreClosed(Project project) {
 			// There is no need to explicitly initialize adapters; the dispose handles uninitialized adapters correctly
+			IncrementalTransformationSynchronizer.disposeSynchronizer(project);
 			ViatraQueryAdapter.disposeAdapter(project);
 		}
 		

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/transformations/IncrementalTransformationSynchronizer.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/transformations/IncrementalTransformationSynchronizer.java
@@ -56,6 +56,10 @@ public class IncrementalTransformationSynchronizer extends TransactionBasedSynch
 		public ModelSynchronizer apply(Project t) {
 			return (ModelSynchronizer) storage.computeIfAbsent(t, IncrementalTransformationSynchronizer::new);
 		}
+		
+	}
+	public static void disposeSynchronizer(Project p) {
+		((ViatraTransformationSynchronizerManager)FACTORY).storage.remove(p);
 	}
 
 	private BatchTransformation transformation;


### PR DESCRIPTION
When a project is closed where an IncrementalTransformationSynchronizer
was initialized, and for an error a reference to the project was kept,
the WeakHashMap entry for the synchronizers were not removed, resulting
in the query engine being kept in memory.

This change ensures that even in such erroneous cases the engine is
disposed by explicitly calling a remove call before a project is closed.