### PR TITLE
#58 Fix early VIATRA engine initialization in ViatraQueryAdapter

### DIFF
--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -52,7 +52,7 @@ public class ViatraQueryAdapter extends AdapterImpl {
 	/**
 	 * @return initialized engine
 	 * @throws ViatraQueryException if engine cannot be initialized yet
-	 * @deprecated Use {@link #getInitializedEngineChecked()} instead
+	 * @deprecated Use {@link #getInitializedEngineChecked()} or {@link #getInitializedEngine()} instead
 	 */
 	@Deprecated
 	public AdvancedViatraQueryEngine getEngine() {

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -132,7 +132,7 @@ public class ViatraQueryAdapter extends AdapterImpl {
 						notifiers = new Notifier[0];
 					} catch (InvocationTargetException ite) {
 						// we can invalidate our engine because there is two option for this exception:
-						// 1. we throw something directly from the callable (but we don't do this)
+						// 1. an exception is thrown directly by the action (which is not supported)
 						// 2. the engine got tainted because of an internal error, making the engine unusable
 						// so even if we execute some action later than the  real initialization of the engine,
 						// the engine will brake down and can't be used anymore

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -53,9 +53,9 @@ public class ViatraQueryAdapter extends AdapterImpl {
 	}
 
 	/**
-	 * @return initialized engine
-	 * @throws ViatraQueryException if engine cannot be initialized yet
 	 * @deprecated Use {@link #getInitializedEngineChecked()} or {@link #getInitializedEngine()} instead
+	 * @return initialized engine
+	 * @throws ViatraQueryException if no query engine was initialized before and initialization failed
 	 */
 	@Deprecated
 	public AdvancedViatraQueryEngine getEngine() {
@@ -63,11 +63,21 @@ public class ViatraQueryAdapter extends AdapterImpl {
 	}
 
 	/**
-	 * Try to initialize the VIATRA engine if it hasn!t been before and if the 
-	 * initialization is not possible, it throws a ViatraQueryException.
-	 * 
+	 * Returns an initialized VIATRA query engine stored in the adapter.
+	 * If a query engine was initialized earlier, that engine will be returned;
+	 * if no query engine was initialized earlier, a new one is created. If
+	 * the initialization fails, e.g. the engine was requested before the
+	 * model was loaded entirely, a {@link ViatraQueryException} is thrown.
+	 * </p>
+	 * This method should only be called if the engine initialization is
+	 * expected to be completed successfully, otherwise it is recommended
+	 * to use {@link #getInitializedEngine()},
+	 * {@link #getInitializedEngine(Consumer)}
+	 * or {@link #requireMatcher(IQuerySpecification)} instead
+	 * as they are aimed to handle the initialization issues better.
+
 	 * @return the initialized engine
-	 * @throws ViatraQueryException if initialized engine is not available yet
+	 * @throws ViatraQueryException if no query engine was initialized before and initialization failed
 	 */
 	public AdvancedViatraQueryEngine getInitializedEngineChecked() {
 		return getInitializedEngine()
@@ -101,7 +111,11 @@ public class ViatraQueryAdapter extends AdapterImpl {
 	 */
 	public Optional<AdvancedViatraQueryEngine> getInitializedEngine(Consumer<AdvancedViatraQueryEngine> action) {
 		if(action != null) {
-			initializationActions.add(action);
+			if(engine.isPresent()) {
+				action.accept(engine.get());
+			} else {
+				initializationActions.add(action);
+			}
 		}
 		return getInitializedEngine();
 	}

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -133,7 +133,7 @@ public class ViatraQueryAdapter extends AdapterImpl {
 					} catch (InvocationTargetException ite) {
 						// we can invalidate our engine because there is two option for this exception:
 						// 1. we throw something directly from the callable (but we don't do this)
-						// 2. the engine goes to tainted and throws something what is wrapped into this -> from this point the engine is unusable
+						// 2. the engine got tainted because of an internal error, making the engine unusable
 						// so even if we execute some action later than the  real initialization of the engine,
 						// the engine will brake down and can't be used anymore
 						LOGGER.error(MESSAGE_ENGINE_PREPARE_ACTION_ERROR, ite);

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -134,7 +134,6 @@ public class ViatraQueryAdapter extends AdapterImpl {
 						// we can invalidate our engine because there is two option for this exception:
 						// 1. an exception is thrown directly by the action (which is not supported)
 						// 2. the engine got tainted because of an internal error, making the engine unusable
-						// so even if we execute some action later than the  real initialization of the engine,
 						// the engine will brake down and can't be used anymore
 						LOGGER.error(MESSAGE_ENGINE_PREPARE_ACTION_ERROR, ite);
 						e.dispose();

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -33,7 +33,7 @@ import com.nomagic.magicdraw.core.ProjectUtilities;
  */
 public class ViatraQueryAdapter extends AdapterImpl {
 	public static final String MESSAGE_ENGINE_NOT_READY = 
-			"VIATRA engine is not available while the primary project is not loaded!";
+			"Cannot initialize VIATRA Query Engine until the project is loaded.";
 	private static final Logger LOGGER = Logger.getLogger(ViatraQueryAdapter.class);
 	
 	private Optional<AdvancedViatraQueryEngine> engine = Optional.empty();

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -104,7 +104,7 @@ public class ViatraQueryAdapter extends AdapterImpl {
 	 * If not, the action will be registered in the list of actions which need to be done 
 	 * when the engine is ready and will be executed when the engine become available.
 	 * 
-	 * @param action the operation which would like to use the initialized VIATRA engine
+	 * @param action the operation which would like to use the initialized VIATRA engine - the action should not throw an exception during execution
 	 * @return the initialized VIATRA engine of it is available, otherwise empty Optional.
 	 */
 	public void executeActionOnEngine(Consumer<AdvancedViatraQueryEngine> action) {

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -122,8 +122,8 @@ public class ViatraQueryAdapter extends AdapterImpl {
 							initializationActions.clear();
 							notifiers = new Notifier[0];
 						} catch (InvocationTargetException ite) {
-							LOGGER.warn(MESSAGE_ENGINE_PREPARE_ACTION_ERROR);
-							engine = null;
+							LOGGER.error(MESSAGE_ENGINE_PREPARE_ACTION_ERROR, ite);
+							e.dispose();
 							thereWasException = true;
 						}
 						return !thereWasException;
@@ -131,6 +131,9 @@ public class ViatraQueryAdapter extends AdapterImpl {
 						LOGGER.warn(MESSAGE_ENGINE_NOT_READY);
 						return false;
 					});
+				if(!isInitialized) {
+					engine = Optional.empty();
+				}
 			}
 		}
 		return engine;

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -100,12 +100,12 @@ public class ViatraQueryAdapter extends AdapterImpl {
 	}
 	
 	/**
-	 * Checks if an engine is available and execute the given action on it if yes.
-	 * If not, the action will be registered in the list of actions which need to be done 
-	 * when the engine is ready and will be executed when the engine become available.
+	 * Executes the give action on the engine associated with the current adapter.
+	 * If the engine is not yet initialized, the action is saved and will be executed
+	 * later when the engine gets initialized.
 	 * 
-	 * @param action the operation which would like to use the initialized VIATRA engine - the action should not throw an exception during execution
-	 * @return the initialized VIATRA engine of it is available, otherwise empty Optional.
+	 * @param action the operation which would like to use the initialized VIATRA engine - 
+	 *               the action should not throw an exception during execution
 	 */
 	public void executeActionOnEngine(Consumer<AdvancedViatraQueryEngine> action) {
 		if(action != null) {

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/ViatraQueryAdapter.java
@@ -134,7 +134,6 @@ public class ViatraQueryAdapter extends AdapterImpl {
 						// we can invalidate our engine because there is two option for this exception:
 						// 1. an exception is thrown directly by the action (which is not supported)
 						// 2. the engine got tainted because of an internal error, making the engine unusable
-						// the engine will brake down and can't be used anymore
 						LOGGER.error(MESSAGE_ENGINE_PREPARE_ACTION_ERROR, ite);
 						e.dispose();
 						thereWasException = true;

--- a/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/expressions/BinaryVQLExpression.java
+++ b/com.incquerylabs.v4md/src/main/com/incquerylabs/v4md/expressions/BinaryVQLExpression.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.viatra.query.runtime.api.ViatraQueryEngine;
+import org.eclipse.viatra.query.runtime.exception.ViatraQueryException;
 
 import com.incquerylabs.v4md.ViatraQueryAdapter;
 import com.nomagic.magicdraw.core.Project;
@@ -33,6 +34,7 @@ import com.nomagic.uml2.ext.magicdraw.classes.mdkernel.Element;
 public class BinaryVQLExpression implements ParameterizedExpression {
 
 	public static final String LANGUAGE = "Binary VQL";
+	public static final String MESSAGE_ADAPTER_NOT_AVAILABLE = "ViatraQueryAdapter is not available for project '%s' yet.";
 
 	protected Project project;
 	protected String className;
@@ -51,7 +53,10 @@ public class BinaryVQLExpression implements ParameterizedExpression {
 	}
 
 	public Object getValue(Element sourceParameter, ValueContext context) throws Exception {
-		ViatraQueryEngine engine = ViatraQueryAdapter.getAdapter(project).get().getEngine();
+		ViatraQueryEngine engine = ViatraQueryAdapter.getAdapter(project).orElseThrow(()-> {
+										String message = String.format(MESSAGE_ADAPTER_NOT_AVAILABLE, project.getName());
+										return new ViatraQueryException(message, message);
+									}).getInitializedEngineChecked();
 
 		List<Object> returnSet = new ArrayList<>();
 		if (provider != null) {
@@ -63,7 +68,7 @@ public class BinaryVQLExpression implements ParameterizedExpression {
 
 	@Override
 	public Class<?> getResultType() {
-		return provider != null ? null : provider.getResultType();
+		return provider == null ? null : provider.getResultType();
 	}
 
 }

--- a/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/ModelUpdateTests.java
+++ b/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/ModelUpdateTests.java
@@ -52,7 +52,7 @@ public class ModelUpdateTests extends MagicDrawTestCase {
 			ViatraQueryLoggingUtil.getLogger(ViatraQueryEngine.class).addAppender(testAppender);
 		}
 		
-		Matcher matcher = PortConnections.Matcher.on(adapter.getEngine());
+		Matcher matcher = PortConnections.Matcher.on(adapter.getInitializedEngineChecked());
 		
 		matcher.countMatches();
 				

--- a/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/QueryTests.java
+++ b/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/QueryTests.java
@@ -3,20 +3,10 @@ package com.incquerylabs.v4md.test;
 import java.io.File;
 import java.io.IOException;
 
-import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
-import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.viatra.query.runtime.api.AdvancedViatraQueryEngine;
 import org.eclipse.viatra.query.runtime.emf.EMFScope;
-import org.eclipse.viatra.query.testing.core.InitializedSnapshotMatchSetModelProvider;
-import org.eclipse.viatra.query.testing.core.ViatraQueryTestCase;
-import org.eclipse.viatra.query.testing.snapshot.QuerySnapshot;
-import org.eclipse.viatra.query.testing.snapshot.SnapshotPackage;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 
 import com.incquerylabs.v4md.ViatraQueryAdapter;
-import com.incquerylabs.v4md.test.provider.V4MDPatternBasedMatchSetProvider;
 import com.incquerylabs.v4md.test.queries.Aggregator_Functions;
 import com.incquerylabs.v4md.test.queries.Block_With_More_than_1_Parent;
 import com.incquerylabs.v4md.test.queries.Check_Expression;
@@ -29,11 +19,6 @@ import com.incquerylabs.v4md.test.queries.Subpattern_Calls;
 import com.incquerylabs.v4md.test.queries.Transitive_Closure;
 import com.incquerylabs.v4md.test.queries.Unreachable_States;
 import com.incquerylabs.v4md.test.runner.TestRunner;
-import com.incquerylabs.v4md.test.snapshot.ISnapshotManager;
-import com.incquerylabs.v4md.test.snapshot.SnapshotAnalyzer;
-import com.incquerylabs.v4md.test.snapshot.SnapshotCreator;
-import com.nomagic.ci.persistence.local.proxy.SnapshotManager;
-import com.nomagic.magicdraw.core.Application;
 import com.nomagic.magicdraw.core.Project;
 import com.nomagic.magicdraw.tests.MagicDrawTestCase;
 import com.nomagic.magicdraw.tests.common.TestEnvironment;
@@ -57,7 +42,7 @@ public class QueryTests extends MagicDrawTestCase {
 
 	protected EMFScope getScopeForProject(Project project) {
 		ViatraQueryAdapter adapter = ViatraQueryAdapter.getOrCreateAdapter(project);
-		AdvancedViatraQueryEngine engine = adapter.getEngine();
+		AdvancedViatraQueryEngine engine = adapter.getInitializedEngineChecked();
 		//V4MD uses EMFScope instances
 	
 		return (EMFScope) engine.getScope();

--- a/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/provider/V4MDPatternBasedMatchSetProvider.java
+++ b/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/provider/V4MDPatternBasedMatchSetProvider.java
@@ -1,7 +1,6 @@
 package com.incquerylabs.v4md.test.provider;
 
 import org.eclipse.emf.ecore.resource.ResourceSet;
-import org.eclipse.viatra.query.runtime.api.AdvancedViatraQueryEngine;
 import org.eclipse.viatra.query.runtime.api.IPatternMatch;
 import org.eclipse.viatra.query.runtime.api.IQuerySpecification;
 import org.eclipse.viatra.query.runtime.api.ViatraQueryMatcher;
@@ -33,7 +32,7 @@ public class V4MDPatternBasedMatchSetProvider implements IMatchSetModelProvider 
 	public <Match extends IPatternMatch> MatchSetRecord getMatchSetRecord(EMFScope scope,
 			IQuerySpecification<? extends ViatraQueryMatcher<Match>> querySpecification, Match filter) {
 
-		ViatraQueryMatcher<Match> matcher = adapter.getEngine().getMatcher(querySpecification);
+		ViatraQueryMatcher<Match> matcher = adapter.getInitializedEngineChecked().getMatcher(querySpecification);
         return helper.createMatchSetRecordForMatcher(matcher,
                 filter == null ? matcher.newEmptyMatch() : filter);
 	}

--- a/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/snapshot/SnapshotCreator.java
+++ b/com.incquerylabs.v4md/src/test/com/incquerylabs/v4md/test/snapshot/SnapshotCreator.java
@@ -37,7 +37,7 @@ public class SnapshotCreator implements ISnapshotManager {
 	@Override
 	public void assertQueryResult(Project project, IQueryGroup queryGroup, String snapshotFileName) {
 		try {
-			ViatraQueryEngine engine = ViatraQueryAdapter.getOrCreateAdapter(project).getEngine();	
+			ViatraQueryEngine engine = ViatraQueryAdapter.getOrCreateAdapter(project).getInitializedEngineChecked();	
 			createAndSaveSnapshot(engine, queryGroup, snapshotFileName);
 		} catch (IOException e) {
 			Assert.fail(e.getMessage());


### PR DESCRIPTION
* provide new API to get engine optionally and be able to initialize it later
* make ViatraQueryAdapter#getEngine method deprecated